### PR TITLE
Allow snapshot names with hyphens

### DIFF
--- a/internal/db_operations.go
+++ b/internal/db_operations.go
@@ -204,7 +204,7 @@ func CreateDatabase(databaseName string) error {
 	}
 	defer database.Close()
 
-	_, err = database.Exec("CREATE DATABASE " + databaseName)
+	_, err = database.Exec("CREATE DATABASE \"" + databaseName + "\"")
 	if err != nil {
 		return fmt.Errorf("failed to create database: %v", err)
 	}
@@ -213,7 +213,7 @@ func CreateDatabase(databaseName string) error {
 }
 
 func CreateDatabaseWithTemplate(database *sql.DB, databaseName, templateDatabaseName string) error {
-	_, err := database.Exec(fmt.Sprintf("CREATE DATABASE %s TEMPLATE %s", databaseName, templateDatabaseName))
+	_, err := database.Exec(fmt.Sprintf("CREATE DATABASE \"%s\" TEMPLATE \"%s\"", databaseName, templateDatabaseName))
 	if err != nil {
 		return fmt.Errorf("failed to create database: %v", err)
 	}

--- a/tests/snapshot_test.go
+++ b/tests/snapshot_test.go
@@ -14,6 +14,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestSnapshot(t *testing.T) {
+	const snapshotName = "production-s1"
+
 	SetupTestDatabase(t)
 	defer TeardownTestContainer(t)
 
@@ -23,18 +25,18 @@ func TestSnapshot(t *testing.T) {
 			t.Fatalf("main.go not found in current directory. Current dir: %s", wd)
 		}
 
-		CreateTestSnapshot(t, "production")
+		CreateTestSnapshot(t, snapshotName)
 
 		os.Chdir("tests")
-		exists, err := internal.DoesDatabaseExist(SnapshotDatabaseName("production"))
+		exists, err := internal.DoesDatabaseExist(SnapshotDatabaseName(snapshotName))
 		if err != nil {
 			t.Fatalf("Error checking database existence: %v", err)
 		}
 		if !exists {
-			t.Errorf("Expected database `%s` to exist - but it does not", SnapshotDatabaseName("production"))
+			t.Errorf("Expected database `%s` to exist - but it does not", SnapshotDatabaseName(snapshotName))
 		}
 
-		CleanupSnapshot("production")
+		CleanupSnapshot(snapshotName)
 	})
 }
 


### PR DESCRIPTION
This change allows some special characters to be used in snapshot names. I wanted to use hyphens (ex. "production-s1"), which didn't work.