### PR TITLE
Add config discovery

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -26,7 +26,7 @@ var (
 )
 
 func initializeProject() {
-	if internal.DoesConfigExist() {
+	if internal.DoesConfigExistInCurrentDir() {
 		fmt.Println("There already is a lunar.yml file in this directory. Please remove it if you want to start over.")
 		return
 	}


### PR DESCRIPTION
Added parent-directory discovery for `lunar.yml`, so commands can run from nested folders without extra flags.   
`init` still only checks the current directory to avoid blocking new configs.