### PR TITLE
Add hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,36 +70,28 @@ Lunar uses a `lunar.yml` configuration file. Run `lunar init` to create one inte
 ### PostgreSQL
 
 ```yaml
-database_url: postgres://localhost:5432/
-database: my_database
+database_url: postgres://localhost:5432/ # Connection URL without database name
+database: my_database                    # Database to snapshot
+maintenance_database: postgres           # Optional - database for admin operations
 ```
-
-#### Options
-
-| Option | Required | Description |
-|--------|----------|-------------|
-| `provider` | No | Set to `postgres` (default if omitted) |
-| `database_url` | Yes | PostgreSQL connection URL without database name |
-| `database` | Yes | Name of the database to snapshot |
-| `maintenance_database` | No | Database for admin operations (default: tries `postgres`, then `template1`) |
 
 ### SQLite
 
 ```yaml
 provider: sqlite
-database_path: ./myapp.db
-snapshot_directory: ./.lunar_snapshots
+database_path: ./myapp.db              # Path relative to lunar.yml
+snapshot_directory: ./.lunar_snapshots # Optional - where snapshots are stored
 ```
 
-#### Options
+### Hooks
 
-| Option | Required | Description |
-|--------|----------|-------------|
-| `provider` | Yes | Must be `sqlite` for SQLite databases |
-| `database_path` | Yes | Path to the SQLite database file (relative or absolute) |
-| `snapshot_directory` | No | Directory to store snapshots (default: `.lunar_snapshots` next to database) |
+```yaml
+# Runs before a snapshot is created - if it fails, the snapshot is aborted
+before_snapshot_command: "psql -d my_database -c 'TRUNCATE TABLE versions;'"
 
-> **Note:** Paths are relative to the `lunar.yml` file location
+# Runs after a snapshot has been restored
+after_restore_command: "bundle exec rails db:migrate"
+```
 
 
 ## Development

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -70,6 +70,22 @@ func getSnapshotNameFromArgsOrPrompt(args []string, manager *internal.Manager, p
 	return selectSnapshot(manager, promptMessage)
 }
 
+func runHookCommand(hookName, command, dir string) error {
+	fmt.Printf("Running %s: %s\n", hookName, command)
+
+	hookCommand := exec.Command("sh", "-c", command)
+	hookCommand.Dir = dir
+	hookCommand.Stdout = os.Stdout
+	hookCommand.Stderr = os.Stderr
+	hookCommand.Stdin = os.Stdin
+
+	if err := hookCommand.Run(); err != nil {
+		return fmt.Errorf("%s failed: %v", hookName, err)
+	}
+
+	return nil
+}
+
 // spawnBackgroundCommand starts a background process with the given arguments.
 // The process runs independently and survives after the parent exits.
 func spawnBackgroundCommand(args ...string) error {

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -64,6 +64,12 @@ func restoreSnapshot(args []string) error {
 			fmt.Printf("Warning: Could not prepare snapshot for next restore: %v\n", err)
 		}
 
+		if config.AfterRestoreCommand != "" {
+			if err := runHookCommand("after_restore_command", config.AfterRestoreCommand, config.ConfigDir()); err != nil {
+				return fmt.Errorf("snapshot was restored, but %v", err)
+			}
+		}
+
 		return nil
 	})
 }

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -55,6 +55,12 @@ func createSnapshot(args []string) error {
 			stopWaitSpinner()
 		}
 
+		if config.BeforeSnapshotCommand != "" {
+			if err := runHookCommand("before_snapshot_command", config.BeforeSnapshotCommand, config.ConfigDir()); err != nil {
+				return fmt.Errorf("snapshot aborted: %v", err)
+			}
+		}
+
 		message := fmt.Sprintf("Creating a snapshot for the database %s", manager.GetDatabaseIdentifier())
 		setInfo, stopSpinner := ui.StartDynamicSpinner(message)
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -25,6 +25,10 @@ type Config struct {
 	DatabasePath      string `yaml:"database_path,omitempty"`
 	SnapshotDirectory string `yaml:"snapshot_directory,omitempty"`
 
+	// Hook commands
+	BeforeSnapshotCommand string `yaml:"before_snapshot_command,omitempty"`
+	AfterRestoreCommand   string `yaml:"after_restore_command,omitempty"`
+
 	configPath string `yaml:"-"`
 	configDir  string `yaml:"-"`
 }
@@ -54,6 +58,10 @@ func (c *Config) GetDatabaseIdentifier() string {
 	default:
 		return c.DatabaseName
 	}
+}
+
+func (c *Config) ConfigDir() string {
+	return c.configDir
 }
 
 func (c *Config) GetResolvedDatabasePath() string {

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -3,6 +3,8 @@ package tests
 import (
 	"os"
 	"testing"
+
+	"github.com/leonvogt/lunar/internal"
 )
 
 // ============================================================================
@@ -41,6 +43,37 @@ func TestPostgres_Restore(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error restoring snapshot: %v", err)
 		}
+
+		os.Chdir("tests")
+		CleanupSnapshot(snapshotName)
+	})
+}
+
+func TestPostgres_AfterRestoreCommand(t *testing.T) {
+	const snapshotName = "pg-after-hook-test"
+	const markerFile = "after_restore_ran.txt"
+
+	SetupTestDatabase(t)
+	defer TeardownTestContainer(t)
+
+	WithTestDirectory(t, func() {
+		CreateTestSnapshot(t, snapshotName)
+
+		hookConfig := *testConfig
+		hookConfig.AfterRestoreCommand = "touch " + markerFile
+		if err := internal.CreateConfigFile(&hookConfig, "lunar.yml"); err != nil {
+			t.Fatalf("Failed to create config file with hook: %v", err)
+		}
+
+		out, err := RunLunarCommand("restore " + snapshotName)
+		if err != nil {
+			t.Errorf("Error restoring snapshot: %v\nOutput: %s", err, string(out))
+		}
+
+		if _, err := os.Stat(markerFile); os.IsNotExist(err) {
+			t.Errorf("Expected after_restore_command to have created `%s` - but it does not exist", markerFile)
+		}
+		os.Remove(markerFile)
 
 		os.Chdir("tests")
 		CleanupSnapshot(snapshotName)

--- a/tests/snapshot_test.go
+++ b/tests/snapshot_test.go
@@ -2,7 +2,10 @@ package tests
 
 import (
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/leonvogt/lunar/internal"
 )
 
 func TestMain(m *testing.M) {
@@ -62,6 +65,75 @@ func TestPostgres_SnapshotAlreadyExists(t *testing.T) {
 		}
 
 		os.Chdir("tests")
+		CleanupSnapshot(snapshotName)
+	})
+}
+
+func TestPostgres_BeforeSnapshotCommand(t *testing.T) {
+	const snapshotName = "pg-before-hook-test"
+	const markerFile = "before_snapshot_ran.txt"
+
+	SetupTestDatabase(t)
+	defer TeardownTestContainer(t)
+
+	WithTestDirectory(t, func() {
+		hookConfig := *testConfig
+		hookConfig.BeforeSnapshotCommand = "touch " + markerFile
+		if err := internal.CreateConfigFile(&hookConfig, "lunar.yml"); err != nil {
+			t.Fatalf("Failed to create config file with hook: %v", err)
+		}
+
+		CreateTestSnapshot(t, snapshotName)
+
+		if _, err := os.Stat(markerFile); os.IsNotExist(err) {
+			t.Errorf("Expected before_snapshot_command to have created `%s` - but it does not exist", markerFile)
+		}
+		os.Remove(markerFile)
+
+		os.Chdir("tests")
+		exists, err := DoesDatabaseExist(SnapshotDatabaseName(snapshotName))
+		if err != nil {
+			t.Fatalf("Error checking database existence: %v", err)
+		}
+		if !exists {
+			t.Errorf("Expected database `%s` to exist - but it does not", SnapshotDatabaseName(snapshotName))
+		}
+
+		CleanupSnapshot(snapshotName)
+	})
+}
+
+func TestPostgres_BeforeSnapshotCommandFailureAbortsSnapshot(t *testing.T) {
+	const snapshotName = "pg-before-hook-failure-test"
+
+	SetupTestDatabase(t)
+	defer TeardownTestContainer(t)
+
+	WithTestDirectory(t, func() {
+		hookConfig := *testConfig
+		hookConfig.BeforeSnapshotCommand = "exit 1"
+		if err := internal.CreateConfigFile(&hookConfig, "lunar.yml"); err != nil {
+			t.Fatalf("Failed to create config file with hook: %v", err)
+		}
+
+		out, err := RunLunarCommand("snapshot " + snapshotName)
+		if err != nil {
+			t.Errorf("Error: %v", err)
+		}
+
+		if !strings.Contains(string(out), "snapshot aborted: before_snapshot_command failed") {
+			t.Errorf("Expected output to mention the aborted snapshot but got '%v'", string(out))
+		}
+
+		os.Chdir("tests")
+		exists, err := DoesDatabaseExist(SnapshotDatabaseName(snapshotName))
+		if err != nil {
+			t.Fatalf("Error checking database existence: %v", err)
+		}
+		if exists {
+			t.Errorf("Expected database `%s` to not exist after failed hook - but it does", SnapshotDatabaseName(snapshotName))
+		}
+
 		CleanupSnapshot(snapshotName)
 	})
 }


### PR DESCRIPTION
Add hooks, which enable to run bash commands before taking a snapshot or after restoring one.   

Example:
```yml
database_url: postgres://localhost:5432/
database: myapp_development
before_snapshot_command: "psql --port 5432 -d myapp_development -c 'TRUNCATE TABLE good_job_executions, good_jobs, good_job_processes, versions;' --dbname myapp_development"
after_restore_command: "bundle exec rails db:migrate"
```